### PR TITLE
Updated version of splunk-universalforwarder to 7.2.3 and both downlo…

### DIFF
--- a/splunkforwarder.nuspec
+++ b/splunkforwarder.nuspec
@@ -5,7 +5,7 @@
     <id>splunk-universalforwarder</id>
     <packageSourceUrl>https://github.com/dagryph/chocolatey-splunkforwarder</packageSourceUrl>
     <title>Splunk Universal Forwarder</title>
-    <version>7.1.1</version>
+    <version>7.2.3</version>
     <authors>Splunk, Inc</authors>
     <owners>Jeffrey Bernt</owners>
     <summary>Splunk Universal Forwarder</summary>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -2,8 +2,8 @@ $ErrorActionPreference = 'Stop'; # stop on all errors
 
 $packageName = $env:ChocolateyPackageName
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86&platform=windows&version=7.1.1&product=universalforwarder&filename=splunkforwarder-7.1.1-8f0ead9ec3db-x86-release.msi&wget=true' # download url, HTTPS preferred
-$url64 = 'https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86_64&platform=windows&version=7.1.1&product=universalforwarder&filename=splunkforwarder-7.1.1-8f0ead9ec3db-x64-release.msi&wget=true' # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
+$url = 'https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86&platform=windows&version=7.2.3&product=universalforwarder&filename=splunkforwarder-7.2.3-06d57c595b80-x86-release.msi&wget=true' # download url, HTTPS preferred
+$url64 = 'https://www.splunk.com/bin/splunk/DownloadActivityServlet?architecture=x86_64&platform=windows&version=7.2.3&product=universalforwarder&filename=splunkforwarder-7.2.3-06d57c595b80-x64-release.msi&wget=true' # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
 
 $packageArgs = @{
     packageName    = $packageName
@@ -13,9 +13,9 @@ $packageArgs = @{
     url64bit       = $url64
 
     softwareName   = 'SplunkUniversalForwarder'
-    checksum       = '675f75f02ceb12cd4531c1128084f3a3'
+    checksum       = '00468A7C83C028971BF965B454F49D7F'
     checksumType   = 'md5'
-    checksum64     = 'bf6fc3004daac0edddf7ddf798c9b9f1'
+    checksum64     = 'EAADA91BCA364B0B3D37163BEB9F4100'
     checksumType64 = $checksumType
 
     silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`" AGREETOLICENSE=YES" # ALLUSERS=1 DISABLEDESKTOPSHORTCUT=1 ADDDESKTOPICON=0 ADDSTARTMENU=0


### PR DESCRIPTION
…ad URLs and MSI file checksums for both 32 and 64 bit versions.

We had a need to upgrade our universal forwarder due to an upcoming upgrade in Splunkcloud software that will require it. 7.2.3 was the latest version of the forwarder at the time I worked on this. The nupkg that was created from this repo with the enclosed changes has been successfully deployed to over 500 Windows servers in our organization. So I thought I'd submit the changes to the community, as it might be useful to others.